### PR TITLE
Windows'ta ayarlar menüsünün açılmasına engel olan config path hatası giderildi.

### DIFF
--- a/internal/utils/history.go
+++ b/internal/utils/history.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"time"
 
 	"github.com/axrona/anitr-cli/internal/player"
@@ -24,30 +23,15 @@ type AnimeHistory map[string]map[string]AnimeHistoryEntry
 
 // getHistoryPath cross-platform olarak history.json yolunu döndürür
 func getHistoryPath() (string, error) {
-	var historyDir string
-	if runtime.GOOS == "windows" {
-		appData := os.Getenv("APPDATA")
-		if appData == "" {
-			appData = os.Getenv("USERPROFILE")
-			if appData == "" {
-				return "", fmt.Errorf("APPDATA ve USERPROFILE bulunamadı")
-			}
-		}
-		historyDir = filepath.Join(appData, "anitr-cli")
-	} else {
-		home := os.Getenv("HOME")
-		if home == "" {
-			return "", fmt.Errorf("HOME bulunamadı")
-		}
-		historyDir = filepath.Join(home, ".anitr-cli")
-	}
+    // ConfigDir() ile aynı yeri kullanarak platformlar arasında tutarlılık sağlar.
+    historyDir := ConfigDir()
 
-	// Klasör yoksa oluştur
-	if err := os.MkdirAll(historyDir, 0o755); err != nil {
-		return "", fmt.Errorf("history klasörü oluşturulamadı: %w", err)
-	}
+    // Klasör yoksa oluştur
+    if err := os.MkdirAll(historyDir, 0o755); err != nil {
+        return "", fmt.Errorf("history klasörü oluşturulamadı: %w", err)
+    }
 
-	return filepath.Join(historyDir, "history.json"), nil
+    return filepath.Join(historyDir, "history.json"), nil
 }
 
 // ReadAnimeHistory history.json'u okur, yoksa yeni oluşturur

--- a/main.go
+++ b/main.go
@@ -412,17 +412,22 @@ func mainMenu(cfx *App, timestamp time.Time) {
 }
 
 func settingsMenu(cfx *App) {
-	cfg, err := utils.LoadConfig(filepath.Join(utils.ConfigDir(), "config.json"))
-	if err != nil {
-		cfg = &utils.Config{}
-	}
+    cfg, err := utils.LoadConfig(filepath.Join(utils.ConfigDir(), "config.json"))
+    if err != nil {
+        cfg = &utils.Config{}
+    }
 
-	// Dosyayı okuma ve yazma modunda açıyoruz, mevcut içeriği sıfırlayarak
-	f, err := os.OpenFile(filepath.Join(utils.ConfigDir(), "config.json"), os.O_RDWR|os.O_CREATE, 0o644)
-	if err != nil {
-		cfx.logger.LogError(err)
-		return
-	}
+    // Dosyayı okuma ve yazma modunda açıyoruz, mevcut içeriği sıfırlayarak
+    // Config klasörü yoksa oluştur (özellikle Windows'ta ilk açılışta yok olabilir)
+    if err := os.MkdirAll(utils.ConfigDir(), 0o755); err != nil {
+        cfx.logger.LogError(fmt.Errorf("config klasörü oluşturulamadı: %w", err))
+        return
+    }
+    f, err := os.OpenFile(filepath.Join(utils.ConfigDir(), "config.json"), os.O_RDWR|os.O_CREATE, 0o644)
+    if err != nil {
+        cfx.logger.LogError(err)
+        return
+    }
 	defer f.Close() // Fonksiyon bitince dosya kapanır
 
 	// JSON yazıcı (Encoder değil)


### PR DESCRIPTION
## 📝 Neler değişti?

- Windows versiyonunda ana menüde ayarlar seçeneği artık çalışıyor.
- config dosyasının yolunu ayarlama sistemi değişti
- config dosyasının yolu geçmiş kaydı ile aynı yerde saklanıyor (AnitrCLI -> anitr-cli)
- config dosyasını yoksa oluşturuyoruzç

## 📌 Sebep?

Windows versiyonunda TUI için Ana menüye eklenen ayarlar seçeneği çalışmıyordu. tekrardan ana menüye atıyordu. Bu sorun config dosyasının path yapılandırmasından dolayı ortaya çıkmaktaydı.
 